### PR TITLE
create bin dir if not exiting yet

### DIFF
--- a/BuildToolsLoaderPlugin.php
+++ b/BuildToolsLoaderPlugin.php
@@ -50,6 +50,10 @@ class BuildToolsLoaderPlugin implements PluginInterface, EventSubscriberInterfac
     public function install()
     {
         $binDir = $this->composer->getConfig()->get('bin-dir');
+
+        // Create bin directory if not existing yet
+        @mkdir($binDir, 0777, true);
+
         $configuredTools = $this->composer->getConfig()->get('standalone-build-tools');
         if (null !== $configuredTools) {
             $this->toolsToInstall = $configuredTools;


### PR DESCRIPTION
This was a bug before. If no previously installed package created it (for example by providing a bin script in composer.json) the call failed with:
  [ErrorException]
  copy(/projectpath/vendor/bin/something.phar): failed to open stream: No such file or directory